### PR TITLE
Frameworks: Allow/Prevent notification light in Zen mode (1 of 2)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -3509,6 +3509,12 @@ public final class Settings {
         public static final String NONE_IS_SILENT = "none_is_silent";
 
         /**
+         * Whether the notification light will be allowed when in zen mode during downtime
+         * @hide
+         */
+        public static final String ALLOW_LIGHTS = "allow_lights";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *
@@ -3591,7 +3597,9 @@ public final class Settings {
             DISPLAY_TEMPERATURE_DAY,
             DISPLAY_TEMPERATURE_MODE,
             DISPLAY_AUTO_OUTDOOR_MODE,
-            LIVE_DISPLAY_HINTED
+            LIVE_DISPLAY_HINTED,
+            NONE_IS_SILENT,
+            ALLOW_LIGHTS
         };
 
         /**

--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -1055,6 +1055,7 @@ public class NotificationManagerService extends SystemService {
         }
         mZenModeHelper.readZenModeFromSetting();
         mZenModeHelper.readSilentModeFromSetting();
+        mZenModeHelper.readLightsAllowedModeFromSetting();
         mInterruptionFilter = mZenModeHelper.getZenModeListenerInterruptionFilter();
 
         mUserProfiles.updateCache(getContext());
@@ -2328,8 +2329,9 @@ public class NotificationManagerService extends SystemService {
         // light
         // release the light
         boolean wasShowLights = mLights.remove(record.getKey());
-        final boolean aboveThresholdWithLight = aboveThreshold || isLedNotificationForcedOn(record);
-        if ((notification.flags & Notification.FLAG_SHOW_LIGHTS) != 0 && aboveThresholdWithLight) {
+        final boolean canInterruptWithLight = canInterrupt || isLedNotificationForcedOn(record)
+                || (!canInterrupt && mZenModeHelper.getAreLightsAllowed());
+        if ((notification.flags & Notification.FLAG_SHOW_LIGHTS) != 0 && canInterruptWithLight) {
             mLights.add(record.getKey());
             updateLightsLocked();
             if (mUseAttentionLight) {

--- a/services/core/java/com/android/server/notification/ZenModeHelper.java
+++ b/services/core/java/com/android/server/notification/ZenModeHelper.java
@@ -81,6 +81,7 @@ public class ZenModeHelper implements AudioManagerInternal.RingerModeDelegate {
     private int mPreviousRingerMode = -1;
     private boolean mEffectsSuppressed;
     private boolean mNoneIsSilent;
+    private boolean mAllowLights;
 
     public ZenModeHelper(Context context, Looper looper) {
         mContext = context;
@@ -262,6 +263,15 @@ public class ZenModeHelper implements AudioManagerInternal.RingerModeDelegate {
     private void setNoneIsSilent(boolean noneIsSilent) {
         mNoneIsSilent = noneIsSilent;
         applyRestrictions();
+    }
+
+    public boolean getAreLightsAllowed() {
+        return mAllowLights;
+    }
+
+    public void readLightsAllowedModeFromSetting() {
+        mAllowLights = System.getIntForUser(mContext.getContentResolver(),
+                System.ALLOW_LIGHTS, 1, UserHandle.USER_CURRENT) == 1;
     }
 
     private void applyRestrictions() {
@@ -527,6 +537,7 @@ public class ZenModeHelper implements AudioManagerInternal.RingerModeDelegate {
     private class SettingsObserver extends ContentObserver {
         private final Uri ZEN_MODE = Global.getUriFor(Global.ZEN_MODE);
         private final Uri NONE_IS_SILENT = System.getUriFor(System.NONE_IS_SILENT);
+        private final Uri ALLOW_LIGHTS = System.getUriFor(System.ALLOW_LIGHTS);
 
         public SettingsObserver(Handler handler) {
             super(handler);
@@ -536,6 +547,7 @@ public class ZenModeHelper implements AudioManagerInternal.RingerModeDelegate {
             final ContentResolver resolver = mContext.getContentResolver();
             resolver.registerContentObserver(ZEN_MODE, false /*notifyForDescendents*/, this);
             resolver.registerContentObserver(NONE_IS_SILENT, false /*notifyForDescendents*/, this);
+            resolver.registerContentObserver(ALLOW_LIGHTS, false /*notifyForDescendents*/, this);
             update(null);
         }
 
@@ -549,6 +561,8 @@ public class ZenModeHelper implements AudioManagerInternal.RingerModeDelegate {
                 readZenModeFromSetting();
             } else if (NONE_IS_SILENT.equals(uri)) {
                 readSilentModeFromSetting();
+            } else if (ALLOW_LIGHTS.equals(uri)) {
+                readLightsAllowedModeFromSetting();
             }
         }
     }


### PR DESCRIPTION
This allows the user to prevent the notification lights from showing during Zen mode as per Android 5.0.x

Change-Id: I831c475204c8647d8ee281094aca837ee9594eb4